### PR TITLE
Improve UX by reducing steps and fixing the channel order

### DIFF
--- a/plugin.video.yelo/.vscode/launch.json
+++ b/plugin.video.yelo/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: aankoppelen",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/plugin.video.yelo/addon.xml
+++ b/plugin.video.yelo/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.yelo" name="Yelo" version="0.0.6" provider-name="shycoderX">
+<addon id="plugin.video.yelo" name="Yelo" version="0.0.7" provider-name="shycoderX">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.inputstreamhelper" version="0.3.4"/>
@@ -7,6 +7,8 @@
         <import addon="script.module.routing" version="0.2.3"/>
         <import addon="script.module.future" version="0.17.1" />
         <import addon="script.module.kodi-six" version="0.1.0" />
+        <import addon="script.module.tornado" version="5.1.1" />
+        <import addon="script.module.web-pdb" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>

--- a/plugin.video.yelo/addon.xml
+++ b/plugin.video.yelo/addon.xml
@@ -8,7 +8,7 @@
         <import addon="script.module.future" version="0.17.1" />
         <import addon="script.module.kodi-six" version="0.1.0" />
         <import addon="script.module.tornado" version="5.1.1" />
-        <import addon="script.module.web-pdb" />
+        <import addon="script.module.ptvsd" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>

--- a/plugin.video.yelo/addon.xml
+++ b/plugin.video.yelo/addon.xml
@@ -7,8 +7,6 @@
         <import addon="script.module.routing" version="0.2.3"/>
         <import addon="script.module.future" version="0.17.1" />
         <import addon="script.module.kodi-six" version="0.1.0" />
-        <import addon="script.module.tornado" version="5.1.1" />
-        <import addon="script.module.ptvsd" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>

--- a/plugin.video.yelo/resources/lib/kodiwrapper/kodiwrapper.py
+++ b/plugin.video.yelo/resources/lib/kodiwrapper/kodiwrapper.py
@@ -32,7 +32,7 @@ class KodiWrapper:
     def create_list_item(self, label, logo, fanart, extra_info = None, playable = "false"):
         list_item = xbmcgui.ListItem()
         list_item.setLabel(label)
-        list_item.setArt({'fanart': fanart, 'icon' : logo, 'thumb': logo})
+        list_item.setArt({'fanart': fanart, 'icon' : logo, 'thumb': fanart})
 
         info = {'title': label}
         if extra_info:

--- a/plugin.video.yelo/resources/lib/kodiwrapper/kodiwrapper.py
+++ b/plugin.video.yelo/resources/lib/kodiwrapper/kodiwrapper.py
@@ -32,7 +32,7 @@ class KodiWrapper:
     def create_list_item(self, label, logo, fanart, extra_info = None, playable = "false"):
         list_item = xbmcgui.ListItem()
         list_item.setLabel(label)
-        list_item.setArt({'fanart': fanart, 'icon' : logo, 'thumb': fanart})
+        list_item.setArt({'fanart': fanart, 'icon' : logo, 'thumb': logo})
 
         info = {'title': label}
         if extra_info:

--- a/plugin.video.yelo/resources/lib/plugin.py
+++ b/plugin.video.yelo/resources/lib/plugin.py
@@ -15,7 +15,10 @@ yelo_player = yelo.YeloPlay(kodi_wrapper, protocols.DASH)
 @routing.route('/')
 def main_menu():
     if yelo_player.login():
-        yelo_player.display_main_menu()
+        data = yelo_player.fetch_channel_list()
+        if data:
+            yelo_player.list_channels(data)
+        #yelo_player.display_main_menu()
 
 
 @routing.route('/listing/livestreams')

--- a/plugin.video.yelo/resources/lib/plugin.py
+++ b/plugin.video.yelo/resources/lib/plugin.py
@@ -18,22 +18,6 @@ def main_menu():
         data = yelo_player.fetch_channel_list()
         if data:
             yelo_player.list_channels(data)
-        #yelo_player.display_main_menu()
-
-
-@routing.route('/listing/livestreams')
-def list_channels():
-    data = yelo_player.fetch_channel_list()
-    if data:
-        yelo_player.list_channels(data)
-
-
-@routing.route('/info/<channel_name>/<logo>/<channel>/<channelId>')
-def channel_info(channel_name, logo, channel, channelId):
-    import base64
-
-    if channel_name and logo and channel:
-        yelo_player.show_info_stream(channel_name, base64.b64decode(logo), channel, channelId)
 
 
 @routing.route('/livestream/<channel>')

--- a/plugin.video.yelo/resources/lib/yelo/yelo.py
+++ b/plugin.video.yelo/resources/lib/yelo/yelo.py
@@ -309,7 +309,6 @@ class YeloPlay(Prepare, Errors):
                 listing.append((url, list_item, is_folder))
 
         self.kodi_wrapper.add_dir_items(listing)
-        self.kodi_wrapper.sort_method(SORT_METHOD_LABEL_IGNORE_THE)
         self.kodi_wrapper.end_directory()
 
     def show_info_stream(self, name, logo, channel, channel_id):


### PR DESCRIPTION
- Removed obsolete first menu 'Livestreams'
- Put currently playing on first and only view/list
- Use same (familiar) order of channels as seen on https://www.yeloplay.be/tv-kijken

To improve the loading speed we should implement async HTTP request logic to get all the channel schedules in parallel before building up the complete list of items.
